### PR TITLE
Always run monit:config before monitoring

### DIFF
--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -41,11 +41,11 @@ namespace :sidekiq do
     desc 'Monitor Sidekiq monit-service'
     task :monitor do
       on roles(fetch(:sidekiq_roles)) do
+        invoke 'sidekiq:monit:config'
         fetch(:sidekiq_processes).times do |idx|
           begin
             sudo_if_needed "#{fetch(:monit_bin)} monitor #{sidekiq_service_name(idx)}"
           rescue
-            invoke 'sidekiq:monit:config'
             sudo_if_needed "#{fetch(:monit_bin)} monitor #{sidekiq_service_name(idx)}"
           end
         end


### PR DESCRIPTION
Because config was only called within the rescue block, changes to
config files would not be uploaded to servers on deployment.

Our fix is to always run config before monitoring. This means config
files will be uploaded every time that `monit:monitor` is run.