### PR TITLE
Extract tasks for reload, add systemctl

### DIFF
--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -34,6 +34,14 @@ namespace :sidekiq do
         mv_command = "mv #{fetch(:tmp_dir)}/monit.conf #{fetch(:sidekiq_monit_conf_dir)}/#{sidekiq_service_name}.conf"
         sudo_if_needed mv_command
 
+        invoke 'sidekiq:monit:reload'
+      end
+    end
+
+    desc 'Reload monit processess and configruaton'
+    task :reload do
+      on roles(fetch(:sidekiq_roles)) do
+        sudo_if_needed "systemctl reload monit.service"
         sudo_if_needed "#{fetch(:monit_bin)} reload"
       end
     end


### PR DESCRIPTION
Even though it's only used once, I thought it would be nice to have an
encapsulated reload command.

Also, adding systemctl reload to this reload step. If you use systemd to
start monit, changes to config files are not recognized until you
restart the service.

This is particular to users of monit that manage the main monit process
via systnemd, so this change is probably not appropriate for the real
capistrano-sidekiq gem, but it is appropriate for our fork of that gem.