### PR TITLE
Force start of daemon process

### DIFF
--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -42,6 +42,7 @@ namespace :sidekiq do
     task :reload do
       on roles(fetch(:sidekiq_roles)) do
         sudo_if_needed "systemctl reload monit.service"
+        sudo_if_needed "#{fetch(:monit_bin)}"
         sudo_if_needed "#{fetch(:monit_bin)} reload"
       end
     end


### PR DESCRIPTION
With `systemd` starting Monit, commands such as `monit reload` don't
work. Even though monit is running (thanks to systemd) there is no
daemonized process, which is what commands like `reload` require.

We can start up a daemonized process quickly by running `monit`, which
is what this commit does.