### PR TITLE
Remove duplicate reload

### DIFF
--- a/lib/capistrano/tasks/monit.rake
+++ b/lib/capistrano/tasks/monit.rake
@@ -41,7 +41,6 @@ namespace :sidekiq do
     desc 'Reload monit processess and configruaton'
     task :reload do
       on roles(fetch(:sidekiq_roles)) do
-        sudo_if_needed "systemctl reload monit.service"
         sudo_if_needed "#{fetch(:monit_bin)} reload"
       end
     end


### PR DESCRIPTION
Mostly reverts #2

I misunderstood the problem I was fixing. The root cause was a host with
two different monit control files. With that fixed the simple `reload`
comamand works as expected

I am keeping this extracted into its own task, though. I think it's
good to have a clear reload task.
.